### PR TITLE
Remove test script compilation limitation

### DIFF
--- a/tutorials/textUiTestingTutorial.md
+++ b/tutorials/textUiTestingTutorial.md
@@ -5,54 +5,54 @@
   `runtest.bat`:
    ```
    @ECHO OFF
-   
+
    REM create bin directory if it doesn't exist
    if not exist ..\bin mkdir ..\bin
-   
+
    REM delete output from previous run
    del ACTUAL.TXT
-   
+
    REM compile the code into the bin folder
-   javac  -cp ..\src -Xlint:none -d ..\bin ..\src\main\java\Duke.java
+   javac  -cp ..\src -Xlint:none -d ..\bin ..\src\main\java\*.java
    IF ERRORLEVEL 1 (
        echo ********** BUILD FAILURE **********
        exit /b 1
    )
    REM no error here, errorlevel == 0
-   
+
    REM run the program, feed commands from input.txt file and redirect the output to the ACTUAL.TXT
    java -classpath ..\bin Duke < input.txt > ACTUAL.TXT
-   
+
    REM compare the output to the expected output
    FC ACTUAL.TXT EXPECTED.TXT
    ```
-   
+
    `runtest.sh`:
    ```shell
    #!/usr/bin/env bash
-   
+
    # create bin directory if it doesn't exist
    if [ ! -d "../bin" ]
    then
        mkdir ../bin
    fi
-   
+
    # delete output from previous run
    if [ -e "./ACTUAL.TXT" ]
    then
        rm ACTUAL.TXT
    fi
-   
+
    # compile the code into the bin folder, terminates if error occurred
-   if ! javac -cp ../src -Xlint:none -d ../bin ../src/main/java/Duke.java
+   if ! javac -cp ../src -Xlint:none -d ../bin ../src/main/java/*.java
    then
        echo "********** BUILD FAILURE **********"
        exit 1
    fi
-   
+
    # run the program, feed commands from input.txt file and redirect the output to the ACTUAL.TXT
    java -classpath ../bin Duke < input.txt > ACTUAL.TXT
-   
+
    # compare the output to the expected output
    diff ACTUAL.TXT EXPECTED.TXT
    if [ $? -eq 0 ]


### PR DESCRIPTION
The current test script fails when there is another file for another class. The revised script compiles all Java files in the `src` directory.